### PR TITLE
Delete the jar file when cleaning

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -105,6 +105,7 @@
 
   <target name="clean" description="clean up" >
     <delete dir="${build}"/>
+    <delete file="${jarfile}" />
   </target>
 
 </project>


### PR DESCRIPTION
When the mspsim folder is linked from the contiki-cooja mspsim build system, the jar file is not deleted by default. This fixes the issue.

tadoº GmbH (www.tado.com)
