### PR TITLE
Improve SimpleProfiler/logcalls

### DIFF
--- a/se/sics/mspsim/core/MSP430Core.java
+++ b/se/sics/mspsim/core/MSP430Core.java
@@ -853,7 +853,7 @@ public class MSP430Core extends Chip implements MSP430Constants {
       if (function == null) {
           function = getFunction(map, dst);
       }
-      profiler.profileCall(function, cpuCycles, pc);
+      profiler.profileCall(function, cycles, pc);
   }
   
   void printWarning(EmulationLogger.WarningType type, int address) throws EmulationException {
@@ -1096,7 +1096,7 @@ public class MSP430Core extends Chip implements MSP430Constants {
             break;
         case MOVA_IND_AUTOINC:
             if (profiler != null && instruction == 0x0110) {
-                profiler.profileReturn(cpuCycles);
+                profiler.profileReturn(cycles);
             }
             writeRegister(PC, pc);
             /* read from address in register */
@@ -2017,7 +2017,7 @@ public class MSP430Core extends Chip implements MSP430Constants {
               updateStatus = false;
 
               if (instruction == RETURN && profiler != null) {
-                  profiler.profileReturn(cpuCycles);
+                  profiler.profileReturn(cycles);
               }
 
               break;

--- a/se/sics/mspsim/profiler/SimpleProfiler.java
+++ b/se/sics/mspsim/profiler/SimpleProfiler.java
@@ -134,7 +134,7 @@ public class SimpleProfiler implements Profiler, EventListener {
         if (servicedInterrupt >= 0) logger.printf("[%2d] ", servicedInterrupt);
         printSpace(logger, (cSP - interruptLevel) * 2);
         logger.println("Call to $" + Utils.hex(entry.getAddress(), 4) +
-                       ": " + entry.getInfo());
+                       ": " + entry.getInfo() + " at " + cycles);
         if (ignoreFunctions.get(entry.getName()) != null) {
           hide = 1;
         }
@@ -231,7 +231,7 @@ public class SimpleProfiler implements Profiler, EventListener {
         if ((cspEntry.hide <= 1) && (!hideIRQ || servicedInterrupt == -1)) {
           if (servicedInterrupt >= 0) logger.printf("[%2d] ",servicedInterrupt);
           printSpace(logger, (cSP - interruptLevel) * 2);
-          logger.println("return from " + ce.function.getInfo() + " elapsed: " + elapsed + " maxStackUsage: " + maxUsage);
+          logger.println("return from " + ce.function.getInfo() + " at " + cycles + " elapsed: " + elapsed + " maxStackUsage: " + maxUsage);
         }
       }
 
@@ -254,7 +254,7 @@ public class SimpleProfiler implements Profiler, EventListener {
 
     PrintStream logger = this.logger;
     if (logger != null && !hideIRQ) {
-      logger.println("----- Interrupt vector " + vector + " start execution -----");
+      logger.println("----- Interrupt vector " + vector + " start execution at " + cycles +  " -----");
     }
   }
   
@@ -267,7 +267,7 @@ public class SimpleProfiler implements Profiler, EventListener {
 
     PrintStream logger = this.logger;
     if (logger != null && !hideIRQ) {
-      logger.println("----- Interrupt vector " + servicedInterrupt + " returned - elapsed: " +
+      logger.println("----- Interrupt vector " + servicedInterrupt + " returned at " + cycles +  " - elapsed: " +
           (cycles - lastInterruptTime[servicedInterrupt]));
     }
     interruptLevel = 0;


### PR DESCRIPTION
Had to find out at which frequency I can run the timer Interrupt and how much code I can execute. This adds more timing information to the SimpleProfiler/logcalls and always shows cycles instead of intermixing it with cpuCycles.
