### PR TITLE
tests: only pass -mmcu once

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,7 +23,7 @@ all:	cputest.firmware timertest.firmware
 
 
 %.firmware:	%.o $(OBJECTS)
-	$(CC) -mmcu=$(MCU) -Wl,-Map=$(@:.firmware=.map) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -Wl,-Map=$(@:.firmware=.map) -o $@ $^
 
 %.ihex: %.firmware
 	$(OBJCOPY) $^ -O ihex $@

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ AR       = msp430-ar
 OBJCOPY  = msp430-objcopy
 STRIP    = msp430-strip
 BSL      = msp430-bsl
-CFLAGSNO = -I. -Wall -mmcu=$(MCU) -g
+CFLAGSNO = -I. -Wall -mmcu=$(MCU) -g -gstabs+
 CFLAGS  += $(CFLAGSNO) -Os
 
 SOURCES := msp430setup.c


### PR DESCRIPTION
Change the order of flags for the firmware
target so CFLAGS with -mmcu comes early and
is only passed once to the compiler.