### PR TITLE
Hacks and fixes to enable picolibc CI on MSP430

### DIFF
--- a/se/sics/mspsim/config/MSP430f5437Config.java
+++ b/se/sics/mspsim/config/MSP430f5437Config.java
@@ -96,7 +96,7 @@ public class MSP430f5437Config extends MSP430Config {
 
         /* configure memory */
         infoMemConfig(0x1800, 128 * 4);
-        mainFlashConfig(0x5c00, 256 * 1024);
+        mainFlashConfig(0x5c00, 768 * 1024);
         ramConfig(0x1c00, 16 * 1024);
         ioMemSize(0x800); /* 2 KB of IO Memory */
         

--- a/se/sics/mspsim/core/DisAsm.java
+++ b/se/sics/mspsim/core/DisAsm.java
@@ -556,16 +556,16 @@ public class DisAsm implements MSP430Constants {
       output += dumpMem(startPC, size, memory);
       output += opstr + " " + srcadr + ", " + dstadr;
 
-      regs = "R" + dstRegister + "=" + Utils.hex16(reg[dstRegister]) +
-	" R" + srcRegister + "=" + Utils.hex16(reg[srcRegister]);
+      regs = "R" + dstRegister + "=" + Utils.hex20(reg[dstRegister]) +
+	" R" + srcRegister + "=" + Utils.hex20(reg[srcRegister]);
       regs += " SR=" + dumpSR(reg[SR]);
-      regs += " SP=" + Utils.hex16(reg[SP]);
+      regs += " SP=" + Utils.hex20(reg[SP]);
       regs += "; as = " + as;
-      srcAddress &= 0xffff;
+      srcAddress &= 0xfffff;
       if (srcAddress != -1) {
-	srcAddress &= 0xffff;
+	srcAddress &= 0xfffff;
 	regs += " sMem:" + Utils.hex16(memory[srcAddress] +
-				       (memory[(srcAddress + 1) % 0xffff]
+				       (memory[(srcAddress + 1) % 0xfffff]
 					<< 8));
       }
     }

--- a/se/sics/mspsim/core/MSP430.java
+++ b/se/sics/mspsim/core/MSP430.java
@@ -55,6 +55,7 @@ public class MSP430 extends MSP430Core {
   private boolean running = false;
   private boolean isBreaking = false;
   private double rate = 2.0;
+  private boolean realtime = true;
 
   // Debug time - measure cycles
   private long lastCycles = 0;
@@ -76,6 +77,10 @@ public class MSP430 extends MSP430Core {
   public MSP430(int type, ComponentRegistry registry, MSP430Config config) {
     super(type, registry, config);
     disAsm = new DisAsm();
+  }
+
+  public void setRealtime(boolean realtime) {
+    this.realtime = realtime;
   }
 
   public double getCPUPercent() {
@@ -135,7 +140,7 @@ public class MSP430 extends MSP430Core {
       }
 
       /* Just a test to see if it gets down to a reasonable speed */
-      if (cycles > nextSleep) {
+      if (realtime && cycles > nextSleep) {
 	try {
 	  Thread.sleep(100);
 	} catch (Exception e) {

--- a/se/sics/mspsim/core/MSP430.java
+++ b/se/sics/mspsim/core/MSP430.java
@@ -38,6 +38,7 @@
 package se.sics.mspsim.core;
 import java.io.PrintStream;
 
+import se.sics.mspsim.core.EmulationLogger.WarningType;
 import se.sics.mspsim.profiler.SimpleProfiler;
 import se.sics.mspsim.util.ArrayUtils;
 import se.sics.mspsim.util.ComponentRegistry;
@@ -48,6 +49,7 @@ public class MSP430 extends MSP430Core {
   private int[] execCounter;
   private int[] trace;
   private int tracePos;
+  private int prevPc = 0;
   
   private boolean debug = false;
   private boolean running = false;
@@ -93,6 +95,9 @@ public class MSP430 extends MSP430Core {
         // ??? - power-up  should be executed?!
         time = System.currentTimeMillis();
         run();
+    } catch (Exception e) {
+	disAsm.disassemble(prevPc, memory, reg);
+	throw(e);
     } finally {
         setRunning(false);
     }
@@ -106,6 +111,7 @@ public class MSP430 extends MSP430Core {
 	nextOut = cycles + 20000007;
       }
 
+      prevPc = reg[PC];
       int pc = emulateOP(-1);
       if (pc >= 0) {
 	if (execCounter != null) {

--- a/se/sics/mspsim/core/MSP430Constants.java
+++ b/se/sics/mspsim/core/MSP430Constants.java
@@ -181,7 +181,7 @@ public interface MSP430Constants {
   public static final int CG2 = 3;
 
   public static final int[][] CREG_VALUES = new int[][]{
-    {0, 0, 4, 8}, {0, 1, 2, 0xffff}
+    {0, 0, 4, 8}, {0, 1, 2, 0xfffff}
   };
 
   public static final int CARRY_B = 0;

--- a/se/sics/mspsim/core/MSP430Core.java
+++ b/se/sics/mspsim/core/MSP430Core.java
@@ -160,6 +160,7 @@ public class MSP430Core extends Chip implements MSP430Constants {
         @Override
         public int read(int address, AccessMode mode, AccessType type) throws EmulationException {
             if (address >= MAX_MEM) {
+		logw(WarningType.EXECUTION, "Read out of bounds");
             	throw new EmulationException("Reading outside memory: 0x" + Utils.hex(address, 4));
             }
             return memorySegments[address >> 8].read(address, mode, type);
@@ -167,6 +168,7 @@ public class MSP430Core extends Chip implements MSP430Constants {
         @Override
         public void write(int address, int data, AccessMode mode) throws EmulationException {
             if (address >= MAX_MEM) {
+		logw(WarningType.EXECUTION, "write out of bounds");
                 throw new EmulationException("Writing outside memory: 0x" + Utils.hex(address, 4));
             }
             memorySegments[address >> 8].write(address, data, mode);

--- a/se/sics/mspsim/core/MSP430Core.java
+++ b/se/sics/mspsim/core/MSP430Core.java
@@ -2069,7 +2069,8 @@ public class MSP430Core extends Chip implements MSP430Constants {
               tmpAdd = 1;
           case SUBC:
               // Both sub and subc does one complement (not) + 1 (or carry)
-              src = (src ^ 0xffff) & 0xffff;
+	      int mask = word ? 0xffff : (wordx20 ? 0xfffff : 0xff);
+              src = (src ^ mask) & mask;
           case ADDC: // ADDC
               if (op == ADDC || op == SUBC)
                   tmpAdd = ((sr & CARRY) > 0) ? 1 : 0;

--- a/se/sics/mspsim/platform/GenericNode.java
+++ b/se/sics/mspsim/platform/GenericNode.java
@@ -237,10 +237,12 @@ public abstract class GenericNode extends Chip implements Runnable {
             WindowUtils.addSaveOnShutdown(key, w);
             w.setVisible(true);
             console.setCommandHandler(ch);
-        } else {
-            ch = new StreamCommandHandler(System.in, System.out, System.err, PROMPT);
+        } else if (config.getPropertyAsBoolean("console", true)) {
+	    ch = new StreamCommandHandler(System.in, System.out, System.err, PROMPT);
+	} else {
+            ch = new CommandHandler(System.out, System.err);
         }
-        registry.registerComponent("commandHandler", ch);
+	registry.registerComponent("commandHandler", ch);
     }
     
     stats = new OperatingModeStatistics(cpu);

--- a/se/sics/mspsim/platform/GenericNode.java
+++ b/se/sics/mspsim/platform/GenericNode.java
@@ -184,7 +184,9 @@ public abstract class GenericNode extends Chip implements Runnable {
       if (fp.canRead()) {
         CommandHandler ch = registry.getComponent(CommandHandler.class, "commandHandler");
         script = script.replace('\\', '/');
-        System.out.println("Autoloading script: " + script);
+	if (!config.getPropertyAsBoolean("quiet", false)) {
+	  System.out.println("Autoloading script: " + script);
+	}
         config.setProperty("autoloadScript", script);
         if (ch != null) {
           ch.lineRead("source \"" + script + '"');
@@ -197,16 +199,19 @@ public abstract class GenericNode extends Chip implements Runnable {
         CommandHandler ch = registry.getComponent(CommandHandler.class, "commandHandler");
         if (ch != null) {
             for (int i = 1; i < args.length; i++) {
-                System.out.println("calling '" + args[i] + "'");
+	        if (!config.getPropertyAsBoolean("quiet", false))
+                  System.out.println("calling '" + args[i] + "'");
                 ch.lineRead(args[i]);
             }
         }
     }
-    System.out.println("-----------------------------------------------");
-    System.out.println("MSPSim " + MSP430Constants.VERSION + " starting firmware: " + firmwareFile);
-    System.out.println("-----------------------------------------------");
-    System.out.print(PROMPT);
-    System.out.flush();
+    if (!config.getPropertyAsBoolean("quiet", false)) {
+	System.out.println("-----------------------------------------------");
+	System.out.println("MSPSim " + MSP430Constants.VERSION + " starting firmware: " + firmwareFile);
+	System.out.println("-----------------------------------------------");
+	System.out.print(PROMPT);
+	System.out.flush();
+    }
   }
 
   public void setup(ConfigManager config) {

--- a/se/sics/mspsim/platform/GenericNode.java
+++ b/se/sics/mspsim/platform/GenericNode.java
@@ -156,6 +156,7 @@ public abstract class GenericNode extends Chip implements Runnable {
     
     setup(config);
 
+    cpu.setRealtime(config.getPropertyAsBoolean("realtime", true));
 
     if (!config.getPropertyAsBoolean("nogui", false)) {
       // Setup control and other UI components

--- a/se/sics/mspsim/platform/tyndall/TyndallNode.java
+++ b/se/sics/mspsim/platform/tyndall/TyndallNode.java
@@ -153,7 +153,19 @@ public class TyndallNode extends GenericNode implements PortListener, USARTListe
                 SerialMon serial = new SerialMon((USARTSource)usart, "USCI A0 Port Output");
                 registry.registerComponent("serialgui", serial);
             }
-        }
+        } else {
+            // Send serial output to stdout
+            IOUnit usart = cpu.getIOUnit("USCI A0");
+            if (usart instanceof USARTSource) {
+		USARTSource usartSource = (USARTSource) usart;
+		USARTListener listener = new USARTListener() {
+			public void dataReceived(USARTSource source, int data) {
+			    System.out.print((char) data);
+			}
+		    };
+		usartSource.addUSARTListener(listener);
+	    }
+	}
     }
 
     public void setupGUI() {


### PR DESCRIPTION
Here's a series of hacks I wrote which allow me to use mspsim to run picolibc tests. There's only one actual fix here -- extending the CG3 -1 value to 20 bits. Everything else just makes the Tyndall emulator capable of working in picolibc CI.
